### PR TITLE
Units, die per Zeus gespawnt werden, Loadouts über GRAD_Factions verteilen

### DIFF
--- a/config_all.hpp
+++ b/config_all.hpp
@@ -40,6 +40,13 @@ class CfgFunctions
     #include "node_modules\grad-customGear\cfgFunctions.hpp"
 };
 
+//Extendend EventHandlers
+class Extended_InitPost_EventHandlers  {
+    class CAManBase {
+         init = "params ['_u']; if !(isPlayer _u) then {[_u] call GRAD_Loadout_fnc_doLoadoutForUnit;};";
+    };
+};
+
 //grad-customGear
 class grad_customGear {
     #include "USERSCRIPTS\customGear.hpp"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "grad-loadout": ">4.0.0",
+        "grad-loadout": ">4.5.0",
         "grad-factions": ">0.1.1",
         "grad-customGear": ">1.0.0"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "grad-loadout": ">4.5.0",
+        "grad-loadout": ">=4.5.0",
         "grad-factions": ">0.1.1",
         "grad-customGear": ">1.0.0"
     }


### PR DESCRIPTION
Automatisch Loadouts an Zeus gespawnete Units verteilen, um "eigene" Factions möglich zu machen ohne diese in einem Mod zu definieren zu müssen. Die Extended Event Handlers benötigen CBA.