### PR TITLE
prevent grad-civs from being initialized early

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -134,7 +134,7 @@ class Loadouts {
 class CfgGradCivs {
 	#include "USER\civSettings.hpp"
 
-    autoInit = 1;
+    autoInit = 0;
     debugMode = 0;
 };
 


### PR DESCRIPTION
autoInit would mean it gets initialized once before the template has set the dynamic config, and a second time after configuration (which leads to mayhem across the board)